### PR TITLE
fix: listen to "batch" hash key in Redis for end of batch

### DIFF
--- a/tests/river/test_batch.py
+++ b/tests/river/test_batch.py
@@ -45,8 +45,8 @@ def test_batch(pyrog_resources, cleanup):
         port=settings.REDIS_COUNTER_PORT,
         db=settings.REDIS_COUNTER_DB
     )
-    # Enable keyspace notifications for keyevent events E
-    # and hash commands h and subscribing to events of key deletion
+    # Enable keyspace notifications for keyevent events
+    # and hash commands
     redis_client.config_set("notify-keyspace-events", "Eh")
     redis_ps = redis_client.pubsub()
     redis_ps.psubscribe(f"__keyevent@{settings.REDIS_COUNTER_DB}__:hdel")
@@ -58,7 +58,7 @@ def test_batch(pyrog_resources, cleanup):
 
     # When a batch ends, the API deletes the corresponding field in the Redis key "batch'.
     # Here we want to get the notification of this event.
-    logger.debug(f"Waiting for stop signal of a batch")
+    logger.debug(f"Waiting for the current batch to end")
     # psubscribe message telling us the subscription works
     msg = redis_ps.get_message(timeout=5.0)
     logger.debug(f"Redis msg: {msg}")
@@ -66,8 +66,7 @@ def test_batch(pyrog_resources, cleanup):
     # The following message signals that a batch has been deleted
     msg = redis_ps.get_message(timeout=settings.BATCH_DURATION_TIMEOUT)
     logger.debug(f"Redis msg: {msg}")
-    assert msg is not None, "No response from Redis"
-    assert msg['data'].decode("utf-8") == "batch", \
+    assert msg is not None and msg['data'].decode("utf-8") == "batch", \
         f"Validation error on Redis message: {msg}"
     # Exit subscribed state. It is required to issue any other command
     redis_ps.reset()

--- a/tests/river/test_batch.py
+++ b/tests/river/test_batch.py
@@ -46,28 +46,28 @@ def test_batch(pyrog_resources, cleanup):
         db=settings.REDIS_COUNTER_DB
     )
     # Enable keyspace notifications for keyevent events E
-    # and generic commands g and subscribing to events of key deletion
-    redis_client.config_set("notify-keyspace-events", "Eg")
+    # and hash commands h and subscribing to events of key deletion
+    redis_client.config_set("notify-keyspace-events", "Eh")
     redis_ps = redis_client.pubsub()
-    redis_ps.psubscribe(f"__keyevent@{settings.REDIS_COUNTER_DB}__:del")
+    redis_ps.psubscribe(f"__keyevent@{settings.REDIS_COUNTER_DB}__:hdel")
 
     # Send Patient and Encounter batch
     batch_id = send_batch(pyrog_resources)
     # UUID will raise a ValueError if batch_id is not a valid uuid
     UUID(batch_id, version=4)
 
-    # When a batch ends, the API deletes the Redis key batch:{batch_id}:resources in Redis.
+    # When a batch ends, the API deletes the corresponding field in the Redis key "batch'.
     # Here we want to get the notification of this event.
-    logger.debug(f"Waiting for stop signal of batch {batch_id}")
+    logger.debug(f"Waiting for stop signal of a batch")
     # psubscribe message telling us the subscription works
     msg = redis_ps.get_message(timeout=5.0)
     logger.debug(f"Redis msg: {msg}")
-    assert msg is not None, f"No response from Redis"
-    # Actual signaling message
+    assert msg is not None, "No response from Redis"
+    # The following message signals that a batch has been deleted
     msg = redis_ps.get_message(timeout=settings.BATCH_DURATION_TIMEOUT)
     logger.debug(f"Redis msg: {msg}")
-    assert msg is not None, f"No response from batch {batch_id}"
-    assert msg['data'].decode("utf-8") == f"batch:{batch_id}:resources", \
+    assert msg is not None, "No response from Redis"
+    assert msg['data'].decode("utf-8") == "batch", \
         f"Validation error on Redis message: {msg}"
     # Exit subscribed state. It is required to issue any other command
     redis_ps.reset()

--- a/tests/river/test_loader_reference_binder.py
+++ b/tests/river/test_loader_reference_binder.py
@@ -47,24 +47,24 @@ def test_batch_reference_binder(store, pyrog_resources):
         db=settings.REDIS_COUNTER_DB
     )
     # Enable keyspace notifications for keyevent events E
-    # and generic commands g
-    redis_client.config_set("notify-keyspace-events", "Eg")
+    # and hash commands h.
+    redis_client.config_set("notify-keyspace-events", "Eh")
     redis_ps = redis_client.pubsub()
-    redis_ps.subscribe(f"__keyevent@{settings.REDIS_COUNTER_DB}__:del")
+    redis_ps.subscribe(f"__keyevent@{settings.REDIS_COUNTER_DB}__:hdel")
 
     # Send Patient and Encounter batch
-    batch_id = send_batch(pyrog_resources)
+    send_batch(pyrog_resources)
 
-    logger.debug(f"Waiting for stop signal of batch {batch_id}")
+    logger.debug(f"Waiting for the current batch to end")
     # psubscribe message
     msg = redis_ps.get_message(timeout=5.0)
     logger.debug(f"Redis msg: {msg}")
-    assert msg is not None, f"No response from Redis"
+    assert msg is not None, "No response from Redis"
     # Actual signaling message
     msg = redis_ps.get_message(timeout=settings.BATCH_DURATION_TIMEOUT)
     logger.debug(f"Redis msg: {msg}")
-    assert msg is not None, f"No response from batch {batch_id}"
-    assert msg['data'].decode("utf-8") == f"batch:{batch_id}:resources", \
+    assert msg is not None, "No response from Redis"
+    assert msg['data'].decode("utf-8") == "batch", \
         f"Validation error on Redis message: {msg}"
 
     # Check reference binding

--- a/tests/river/test_loader_reference_binder.py
+++ b/tests/river/test_loader_reference_binder.py
@@ -46,8 +46,8 @@ def test_batch_reference_binder(store, pyrog_resources):
         port=settings.REDIS_COUNTER_PORT,
         db=settings.REDIS_COUNTER_DB
     )
-    # Enable keyspace notifications for keyevent events E
-    # and hash commands h.
+    # Enable keyspace notifications for keyevent events
+    # and hash commands
     redis_client.config_set("notify-keyspace-events", "Eh")
     redis_ps = redis_client.pubsub()
     redis_ps.subscribe(f"__keyevent@{settings.REDIS_COUNTER_DB}__:hdel")
@@ -63,8 +63,7 @@ def test_batch_reference_binder(store, pyrog_resources):
     # Actual signaling message
     msg = redis_ps.get_message(timeout=settings.BATCH_DURATION_TIMEOUT)
     logger.debug(f"Redis msg: {msg}")
-    assert msg is not None, "No response from Redis"
-    assert msg['data'].decode("utf-8") == "batch", \
+    assert msg is not None and msg['data'].decode("utf-8") == "batch", \
         f"Validation error on Redis message: {msg}"
 
     # Check reference binding


### PR DESCRIPTION
## Description
<!-- Concisely describe what the pull request does. -->
When a batch ends, the batch id field in the hash "batch" in Redis is deleted. It is used here to catch the end of the batch.

## Technical details
<!-- Add any other information or technical details about the implementation; or delete the section entirely. -->
Refers to https://github.com/arkhn/fhir-river/pull/212
